### PR TITLE
add notification feature using apprise package

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -42,6 +42,12 @@ LogFile = ./log/certstreammonitor.log
 # %%M -> minute
 Alerts_dir = ./alerts/%%Y/%%m/%%d
 
+# (optional) Notifications: you can specify a notification destination. It will push to it each hostname detected as UP (+ all informations present in the JSON file).
+# Notification Destination syntax and supported services are described on the apprise package Github page:
+#   https://github.com/caronc/apprise
+# Example of Notification_Destination for sending email over SMTPS :
+#Notification_Destination = mailtos://domain.xyz?user=smtp-user&pass=user-password&smtp=smtp-server-hostname&to=recipient-address&from=send-address&format=text&name=CertStreamMonitor-notification
+
 [SERVER]
 # Connection to Certficate Transparency aggregator server
 # (optional) Declare a HTTP proxy to use to connect to Certficate Transparency aggregator server
@@ -54,4 +60,4 @@ ACTServer = wss://certstream.calidog.io
 [SAFEBROWSING]
 # Set the Google Safe Browsing API key value with your own
 # if you want to test each hostname that is up against the GSB Lookup API
-# Safe_Browsing_API_Key = value
+#Safe_Browsing_API_Key = value

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ipwhois
 PySocks
 hues
 websocket-client==0.48.0
+apprise

--- a/utils/confparser.py
+++ b/utils/confparser.py
@@ -37,6 +37,10 @@ class ConfParser:
 
                 # Reporting
                 self.Alerts_dir = self.config['REPORTING']['Alerts_dir']
+                try:
+                    self.Notification_Destination = self.config['REPORTING']['Notification_Destination']
+                except:
+                    self.Notification_Destination = None
 
                 # User Agent
                 self.http_UA = self.config['CONNECT']['http_UA']


### PR DESCRIPTION
List of the changes : 
- add `apprise` package to requirements
- add a config parameter (`Notification_Destination`) to set a destination (email, Slack, twitter etc) of the notification that are sent when `scanhost.py` detects a new hostname that is UP
- modify the config parameters handling in order to process the new parameter
- add notification generation in `scanhost.py` when the `Notification_Destination` config parameter is set