### PR TITLE
Feature/more configurable logging

### DIFF
--- a/CertStreamMonitor.py
+++ b/CertStreamMonitor.py
@@ -49,6 +49,8 @@ def ConfAnalysis(ConfFile):
     global DBFile
     global TABLEname
     global LogFile
+    global LogLevel
+    global LogType
     global SearchKeywords
     global BlacklistKeywords
     global DetectionThreshold
@@ -64,6 +66,8 @@ def ConfAnalysis(ConfFile):
         DBFile = CONF.DBFile
         TABLEname = CONF.TABLEname
         LogFile = CONF.LogFile
+        LogLevel = CONF.LogLevel
+        LogType = CONF.LogType
         SearchKeywords = CONF.SearchKeywords
         BlacklistKeywords = CONF.BlacklistKeywords
         DetectionThreshold = CONF.DetectionThreshold
@@ -169,20 +173,22 @@ def main():
 
         # logging
         logger = logging.getLogger()
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(LogLevel)
 
         # file handler (10MB, 10 rotations)
-        format = logging.Formatter(
-            '[%(levelname)s:%(name)s] %(asctime)s - %(message)s')
-        file_handler = RotatingFileHandler(LogFile, 'a', 10000000, 10)
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(format)
-        logger.addHandler(file_handler)
-
-        # term handler
-        stream_handler = logging.StreamHandler()
-        stream_handler.setLevel(logging.INFO)
-        logger.addHandler(stream_handler)
+        if LogType == 'file':
+            format = logging.Formatter(
+                '[%(levelname)s:%(name)s] %(asctime)s - %(message)s')
+            file_handler = RotatingFileHandler(LogFile, 'a', 10000000, 10)
+            file_handler.setFormatter(format)
+            logger.addHandler(file_handler)
+        # syslog handler
+        elif LogType == 'syslog':
+            stream_handler = logging.StreamHandler()
+            logger.addHandler(stream_handler)
+        else:
+            logging.error("Unsupported log type " + LogType + ". Exiting...")
+            sys.exit(1)
 
         # Work, connection to the CT logs aggregator (ACTServer), through a HTTP proxy if configured into configuration file
         logging.info("Looking for these strings: " + SearchKeywords +

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -35,6 +35,8 @@ UAfile = ./useragent_list.txt
 [LOGGING]
 # Logging file (will be created if not exist)
 LogFile = ./log/certstreammonitor.log
+LogLevel = DEBUG
+LogType = file
 
 [REPORTING]
 # Alerts reporting directory for scanhost.py

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -35,7 +35,7 @@ UAfile = ./useragent_list.txt
 [LOGGING]
 # Logging file (will be created if not exist)
 LogFile = ./log/certstreammonitor.log
-LogLevel = DEBUG
+LogLevel = 10
 LogType = file
 
 [REPORTING]

--- a/utils/confparser.py
+++ b/utils/confparser.py
@@ -32,6 +32,14 @@ class ConfParser:
 
                 # Logging
                 self.LogFile = self.config['LOGGING']['LogFile']
+                try:
+                    self.LogLevel = self.config['LOGGING']['LogLevel']
+                except:
+                    self.LogLevel = logging.DEBUG
+                try:
+                    self.LogType = self.config['LOGGING']['LogType']
+                except:
+                    self.LogType = 'file'
 
                 # Proxy
                 try:


### PR DESCRIPTION
Current code forces log level, and force syslog usage in addition to a log file. Given issue #35, it results in an endless pollution of system logs:

CertStreamMonitor.py[499222]: Connection to remote host was lost. - goodbye
CertStreamMonitor.py[499222]: Websocket connected
CertStreamMonitor.py[499222]: Connection established to CertStream! Listening for events...
CertStreamMonitor.py[499222]: Error connecting to CertStream - Connection to remote host was lost. - Sleeping for a few seconds and trying again...

This PR allow to use either log file or syslog, as well as selecting proper log level.
