### PR TITLE
convert LogLevel to int

### DIFF
--- a/CertStreamMonitor.py
+++ b/CertStreamMonitor.py
@@ -67,6 +67,8 @@ def ConfAnalysis(ConfFile):
         TABLEname = CONF.TABLEname
         LogFile = CONF.LogFile
         LogLevel = CONF.LogLevel
+        #LogLevel needs to be converted to int
+        LogLevel = int(LogLevel)  
         LogType = CONF.LogType
         SearchKeywords = CONF.SearchKeywords
         BlacklistKeywords = CONF.BlacklistKeywords


### PR DESCRIPTION
the LogLevel read from the configuration file is a str. Thus, it needs to be converted to int.